### PR TITLE
feat: Implement expandable item descriptions on actor sheets

### DIFF
--- a/css/swnr.css
+++ b/css/swnr.css
@@ -32,71 +32,6 @@
   cursor: pointer;
 }
 
-/* Styles for expandable item descriptions */
-[data-action="toggle-description"] {
-  cursor: pointer;
-  /* Consider a specific color for the link if needed */
-  /* color: var(--active-font-color); */ /* Example */
-}
-
-[data-action="toggle-description"]:hover {
-  text-decoration: underline;
-  color: var(--active-font-color); /* Using variable defined in .swnr scope */
-}
-
-.item-description-row {
-  list-style-type: none; /* Remove bullet points for li elements */
-  padding: 0; /* Reset padding */
-  margin: 0; /* Reset margin */
-  /* Ensure it doesn't have the bottom border from the item above */
-  border-bottom: none; 
-}
-
-/* The container for the description text itself */
-.item-description {
-  padding: 8px;
-  margin-top: 5px;   /* Space between the item name and the description box */
-  margin-bottom: 10px; /* Space after the description box */
-  background-color: rgba(0, 0, 0, 0.03); /* Subtle background, should work on light/dark */
-  border-left: 3px solid var(--swnr-c-beige); /* Accent border, uses theme variable */
-  border-radius: 2px; /* Slightly rounded corners */
-  clear: both; /* Just in case of floats, though flex is mainly used */
-  width: 100%;
-  box-sizing: border-box; /* Ensures padding is included in the width */
-  font-size: 13px; /* Match item name font size */
-  line-height: 1.4; /* Improve readability */
-  color: var(--swnr-c-tan); /* Match other item text color */
-}
-
-/* Specific padding for descriptions within standard item lists to align with names */
-.items-list > .item-description-row > .item-description {
-    margin-left: 35px; /* Align with item name text (after 30px image + 5px margin) */
-    width: calc(100% - 35px); /* Adjust width to account for the margin */
-}
-
-/* Adjust description indentation for Readied Armor list (where checkbox replaces image) */
-.swnr .readied-armor-list > .item-description-row > .item-description {
-  margin-left: 10px; /* Smaller margin for lists without item image before name */
-  width: calc(100% - 10px); /* Correspondingly adjust width */
-}
-
-/* For powers, the structure might be different, adjust if they don't have an image or similar offset */
-/* Example: if powers list items don't have an image before the name */
-/* .powers-list > .item-description-row > .item-description { */
-  /* margin-left: 5px; */ /* Or some other suitable value */
-  /* width: calc(100% - 5px); */
-/* } */
-
-/* Ensure the description row itself doesn't pick up unwanted borders from .item styles */
-.swnr .items-list .item-description-row {
-  border-bottom: none; /* Explicitly remove border for these rows */
-}
-
-/* If the description is the very last element in an items-list, remove its bottom margin */
-.swnr .items-list .item-description-row:last-child > .item-description {
-  margin-bottom: 0;
-}
-
 .grid,
 .grid-2col {
   display: grid;
@@ -303,7 +238,6 @@
 .swnr .sheet-header.column {
   flex-direction: column;
 }
-
 .swnr .sheet-header .header-fields {
   flex: 1;
 }
@@ -813,6 +747,47 @@
 .swnr .asset-prop .asset-damage {
   flex: 0 1 40px;
   padding: 0 8px;
+}
+.swnr [data-action=toggle-description] {
+  cursor: pointer;
+}
+.swnr [data-action=toggle-description]:hover {
+  text-decoration: underline;
+  color: var(--active-font-color);
+}
+.swnr .item-description-row {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  border-bottom: none;
+}
+.swnr .item-description {
+  padding: 8px;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  background-color: rgba(0, 0, 0, 0.03);
+  border-left: 3px solid var(--swnr-c-beige);
+  border-radius: 2px;
+  clear: both;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--swnr-c-tan);
+}
+.swnr .items-list > .item-description-row > .item-description {
+  margin-left: 35px;
+  width: calc(100% - 35px);
+}
+.swnr .readied-armor-list > .item-description-row > .item-description {
+  margin-left: 10px;
+  width: calc(100% - 10px);
+}
+.swnr .items-list .item-description-row {
+  border-bottom: none;
+}
+.swnr .items-list .item-description-row:last-child > .item-description {
+  margin-bottom: 0;
 }
 .swnr .effects-header {
   height: 28px;

--- a/css/swnr.css
+++ b/css/swnr.css
@@ -74,6 +74,12 @@
     width: calc(100% - 35px); /* Adjust width to account for the margin */
 }
 
+/* Adjust description indentation for Readied Armor list (where checkbox replaces image) */
+.swnr .readied-armor-list > .item-description-row > .item-description {
+  margin-left: 10px; /* Smaller margin for lists without item image before name */
+  width: calc(100% - 10px); /* Correspondingly adjust width */
+}
+
 /* For powers, the structure might be different, adjust if they don't have an image or similar offset */
 /* Example: if powers list items don't have an image before the name */
 /* .powers-list > .item-description-row > .item-description { */

--- a/css/swnr.css
+++ b/css/swnr.css
@@ -347,18 +347,14 @@
 }
 
 /* Actor Sheet Header - Level and XP field width adjustments */
-.swnr .sheet-header .resources.grid-5col > .actor-header-level-container {
-  flex-grow: 0.5; /* Attempt to make it half the 'standard' column width */
-  flex-shrink: 1;
-  flex-basis: 0; /* Allow it to shrink or grow from a zero basis based on flex-grow */
-  min-width: 60px; /* Add a minimum width to prevent it from becoming too small */
+.swnr .sheet-header .resources .actor-header-level-container .resource-content {
+  max-width: 60px; /* Makes the content area of Level field narrower */
+  margin-left: auto; /* Centers the content within its grid cell */
+  margin-right: auto; /* Centers the content within its grid cell */
 }
 
-.swnr .sheet-header .resources.grid-5col > .actor-header-xp-container {
-  flex-grow: 2;   /* Attempt to make it double the 'standard' column width */
-  flex-shrink: 1;
-  flex-basis: 0;
-  min-width: 100px; /* Add a minimum width for XP field */
+.swnr .sheet-header .resources .actor-header-xp-container {
+  grid-column: span 2; /* Makes the XP field container span 2 grid columns */
 }
 
 .swnr .sheet-header .header-fields {

--- a/css/swnr.css
+++ b/css/swnr.css
@@ -32,6 +32,65 @@
   cursor: pointer;
 }
 
+/* Styles for expandable item descriptions */
+[data-action="toggle-description"] {
+  cursor: pointer;
+  /* Consider a specific color for the link if needed */
+  /* color: var(--active-font-color); */ /* Example */
+}
+
+[data-action="toggle-description"]:hover {
+  text-decoration: underline;
+  color: var(--active-font-color); /* Using variable defined in .swnr scope */
+}
+
+.item-description-row {
+  list-style-type: none; /* Remove bullet points for li elements */
+  padding: 0; /* Reset padding */
+  margin: 0; /* Reset margin */
+  /* Ensure it doesn't have the bottom border from the item above */
+  border-bottom: none; 
+}
+
+/* The container for the description text itself */
+.item-description {
+  padding: 8px;
+  margin-top: 5px;   /* Space between the item name and the description box */
+  margin-bottom: 10px; /* Space after the description box */
+  background-color: rgba(0, 0, 0, 0.03); /* Subtle background, should work on light/dark */
+  border-left: 3px solid var(--swnr-c-beige); /* Accent border, uses theme variable */
+  border-radius: 2px; /* Slightly rounded corners */
+  clear: both; /* Just in case of floats, though flex is mainly used */
+  width: 100%;
+  box-sizing: border-box; /* Ensures padding is included in the width */
+  font-size: 13px; /* Match item name font size */
+  line-height: 1.4; /* Improve readability */
+  color: var(--swnr-c-tan); /* Match other item text color */
+}
+
+/* Specific padding for descriptions within standard item lists to align with names */
+.items-list > .item-description-row > .item-description {
+    margin-left: 35px; /* Align with item name text (after 30px image + 5px margin) */
+    width: calc(100% - 35px); /* Adjust width to account for the margin */
+}
+
+/* For powers, the structure might be different, adjust if they don't have an image or similar offset */
+/* Example: if powers list items don't have an image before the name */
+/* .powers-list > .item-description-row > .item-description { */
+  /* margin-left: 5px; */ /* Or some other suitable value */
+  /* width: calc(100% - 5px); */
+/* } */
+
+/* Ensure the description row itself doesn't pick up unwanted borders from .item styles */
+.swnr .items-list .item-description-row {
+  border-bottom: none; /* Explicitly remove border for these rows */
+}
+
+/* If the description is the very last element in an items-list, remove its bottom margin */
+.swnr .items-list .item-description-row:last-child > .item-description {
+  margin-bottom: 0;
+}
+
 .grid,
 .grid-2col {
   display: grid;

--- a/css/swnr.css
+++ b/css/swnr.css
@@ -345,6 +345,22 @@
 .swnr .sheet-header.column {
   flex-direction: column;
 }
+
+/* Actor Sheet Header - Level and XP field width adjustments */
+.swnr .sheet-header .resources.grid-5col > .actor-header-level-container {
+  flex-grow: 0.5; /* Attempt to make it half the 'standard' column width */
+  flex-shrink: 1;
+  flex-basis: 0; /* Allow it to shrink or grow from a zero basis based on flex-grow */
+  min-width: 60px; /* Add a minimum width to prevent it from becoming too small */
+}
+
+.swnr .sheet-header .resources.grid-5col > .actor-header-xp-container {
+  flex-grow: 2;   /* Attempt to make it double the 'standard' column width */
+  flex-shrink: 1;
+  flex-basis: 0;
+  min-width: 100px; /* Add a minimum width for XP field */
+}
+
 .swnr .sheet-header .header-fields {
   flex: 1;
 }

--- a/css/swnr.css
+++ b/css/swnr.css
@@ -346,17 +346,6 @@
   flex-direction: column;
 }
 
-/* Actor Sheet Header - Level and XP field width adjustments */
-.swnr .sheet-header .resources .actor-header-level-container .resource-content {
-  max-width: 60px; /* Makes the content area of Level field narrower */
-  margin-left: auto; /* Centers the content within its grid cell */
-  margin-right: auto; /* Centers the content within its grid cell */
-}
-
-.swnr .sheet-header .resources .actor-header-xp-container {
-  grid-column: span 2; /* Makes the XP field container span 2 grid columns */
-}
-
 .swnr .sheet-header .header-fields {
   flex: 1;
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -838,14 +838,14 @@ export class SWNActorSheet extends SWNBaseSheet {
    */
   static async _onToggleDescription(event, target) {
     event.preventDefault();
-    const itemId = target.dataset.itemId;
-    if (!itemId) {
-      console.warn("SWNR | toggle-description action called without item-id");
+    const descriptionId = target.dataset.descriptionId; // Use the new attribute
+    if (!descriptionId) {
+      console.warn("SWNR | toggle-description action called without data-description-id");
       return;
     }
 
-    const descriptionElement = this.element.querySelector(`#item-description-${itemId}`);
-
+    const descriptionElement = this.element.querySelector(`#${descriptionId}`); // Query by the full ID
+    
     if (descriptionElement) {
       if (descriptionElement.style.display === "none" || !descriptionElement.style.display) {
         descriptionElement.style.display = "block"; 
@@ -853,7 +853,7 @@ export class SWNActorSheet extends SWNBaseSheet {
         descriptionElement.style.display = "none";
       }
     } else {
-      console.warn(`SWNR | Description element not found for item ID: ${itemId}`);
+      console.warn(`SWNR | Description element not found for ID: ${descriptionId}`);
     }
   }
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -50,6 +50,7 @@ export class SWNActorSheet extends SWNBaseSheet {
       moraleRoll: this._onMoraleRoll,
       resourceCreate: this._onResourceCreate,
       resourceDelete: this._onResourceDelete,
+      'toggle-description': this._onToggleDescription,
     },
     // Custom property that's merged into `this.options`
     dragDrop: [{ dragSelector: '[data-drag]', dropSelector: null }],
@@ -826,5 +827,33 @@ export class SWNActorSheet extends SWNBaseSheet {
     const resourceList = duplicate(this.actor.system.tweak.resourceList);
     resourceList[idx][resourceType] = value;
     await this.actor.update({ "system.tweak.resourceList": resourceList });
+  }
+
+  /**
+   * Toggle item description visibility.
+   * @this SWNActorSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   * @protected
+   */
+  static async _onToggleDescription(event, target) {
+    event.preventDefault();
+    const itemId = target.dataset.itemId;
+    if (!itemId) {
+      console.warn("SWNR | toggle-description action called without item-id");
+      return;
+    }
+
+    const descriptionElement = this.element.querySelector(`#item-description-${itemId}`);
+
+    if (descriptionElement) {
+      if (descriptionElement.style.display === "none" || !descriptionElement.style.display) {
+        descriptionElement.style.display = "block"; 
+      } else {
+        descriptionElement.style.display = "none";
+      }
+    } else {
+      console.warn(`SWNR | Description element not found for item ID: ${itemId}`);
+    }
   }
 }

--- a/src/scss/components/_items.scss
+++ b/src/scss/components/_items.scss
@@ -285,3 +285,63 @@
     padding: 0 8px;
   }
 }
+
+// -----------------------------------------
+// Expandable Item Descriptions
+// -----------------------------------------
+
+// Toggle button for expandable descriptions
+[data-action="toggle-description"] {
+  cursor: pointer;
+  
+  &:hover {
+    text-decoration: underline;
+    color: var(--active-font-color);
+  }
+}
+
+// Container row for the description
+.item-description-row {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  border-bottom: none; // Ensure it doesn't inherit item borders
+}
+
+// The description content box
+.item-description {
+  padding: 8px;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  background-color: rgba(0, 0, 0, 0.03);
+  border-left: 3px solid var(--swnr-c-beige);
+  border-radius: 2px;
+  clear: both;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--swnr-c-tan);
+}
+
+// Specific positioning for different list types
+.items-list > .item-description-row > .item-description {
+  margin-left: 35px; // Align with item name (after 30px image + 5px margin)
+  width: calc(100% - 35px);
+}
+
+// Special case for readied armor list (checkbox instead of image)
+.readied-armor-list > .item-description-row > .item-description {
+  margin-left: 10px;
+  width: calc(100% - 10px);
+}
+
+// Ensure description rows don't pick up unwanted borders
+.items-list .item-description-row {
+  border-bottom: none;
+}
+
+// Remove bottom margin if description is the last element in a list
+.items-list .item-description-row:last-child > .item-description {
+  margin-bottom: 0;
+}

--- a/templates/actor/combat.hbs
+++ b/templates/actor/combat.hbs
@@ -192,7 +192,11 @@
       </a>
     </div> --}}
 
-  </div>    
+  </div>
+
+      {{!-- Readied Weapons --}}
+      {{> "systems/swnr/templates/actor/fragments/compact-weapon-list.hbs" itemList=actor.system.readiedWeapons actorType=actor.type }}
+
       {{else}}
       <button class="skill-load-button" type="button" data-action="loadSkills">
         {{localize 'swnr.sheet.loadSkills'}}
@@ -252,9 +256,6 @@
       {{/each}}
       </ol>
       {{/if}}
-
-      {{!-- Readied Weapons --}}
-      {{> "systems/swnr/templates/actor/fragments/compact-weapon-list.hbs" itemList=actor.system.readiedWeapons actorType=actor.type }}
 
       {{!-- Readied Armor --}}
       {{> "systems/swnr/templates/actor/fragments/compact-armor-list.hbs" itemList=actor.system.readiedArmor actorType=actor.type }}

--- a/templates/actor/combat.hbs
+++ b/templates/actor/combat.hbs
@@ -231,7 +231,7 @@
                 />
               </a>
             </div>
-            <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a></div>
+            <div><a data-action="toggle-description" data-item-id="{{item._id}}" data-description-id="desc-combatfav-{{item._id}}">{{item.name}}</a></div>
           </div>
           <div class="item-qty"> {{ item.system.quantity }} </div>
           <div class='item-controls-small'>
@@ -245,7 +245,7 @@
           </div>
         </li>
         <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
-          <div class='item-description' id='item-description-{{item._id}}' style='display: none;'>
+          <div class='item-description' id='desc-combatfav-{{item._id}}' style='display: none;'>
             {{{item.system.description}}}
           </div>
         </li>

--- a/templates/actor/combat.hbs
+++ b/templates/actor/combat.hbs
@@ -231,7 +231,7 @@
                 />
               </a>
             </div>
-            <div>{{item.name}}</div>
+            <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a></div>
           </div>
           <div class="item-qty"> {{ item.system.quantity }} </div>
           <div class='item-controls-small'>
@@ -242,6 +242,11 @@
             >
               <i class='fas fa-edit'></i>
             </a>
+          </div>
+        </li>
+        <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
+          <div class='item-description' id='item-description-{{item._id}}' style='display: none;'>
+            {{{item.system.description}}}
           </div>
         </li>
       {{/each}}

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -130,7 +130,7 @@
                     />
                   </a>
                 </div>
-                <div>{{item.name}}</div>
+                <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a></div>
               </div>
               <div class='item-level' style='display: flex; justify-content: center;'>
                 {{localize (concat 'swnr.featureTypes.' item.system.type)}}
@@ -155,6 +155,11 @@
                     <i class='fas fa-trash'></i>
                   </a>
                 {{/if}}
+              </div>
+            </li>
+            <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
+              <div class='item-description' id='item-description-{{item._id}}' style='display: none;'>
+                {{{item.system.description}}}
               </div>
             </li>
           {{/each}}

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -130,7 +130,7 @@
                     />
                   </a>
                 </div>
-                <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a></div>
+                <div><a data-action="toggle-description" data-item-id="{{item._id}}" data-description-id="desc-features-{{item._id}}">{{item.name}}</a></div>
               </div>
               <div class='item-level' style='display: flex; justify-content: center;'>
                 {{localize (concat 'swnr.featureTypes.' item.system.type)}}
@@ -158,7 +158,7 @@
               </div>
             </li>
             <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
-              <div class='item-description' id='item-description-{{item._id}}' style='display: none;'>
+              <div class='item-description' id='desc-features-{{item._id}}' style='display: none;'>
                 {{{item.system.description}}}
               </div>
             </li>

--- a/templates/actor/fragments/compact-abilities-list.hbs
+++ b/templates/actor/fragments/compact-abilities-list.hbs
@@ -34,7 +34,8 @@
               </a>
             </div>
 
-            <div>{{item.name}}
+            <div>
+              <a data-action="toggle-description" data-item-id="{{item._id}}" data-description-id="desc-abilities-{{item._id}}">{{item.name}}</a>
             </div>
           </div>
           <div class='item-controls-small'>
@@ -56,6 +57,13 @@
             {{/if}}
           </div>
         </li>
+        {{#if item.system.description}}
+          <li class="item-description-row" data-item-id="{{item._id}}">
+            <div class="item-description" id="desc-abilities-{{item._id}}" style="display: none;">
+              {{{item.system.description}}}
+            </div>
+          </li>
+        {{/if}}
       {{/each}}
 
     </ol>

--- a/templates/actor/fragments/compact-armor-list.hbs
+++ b/templates/actor/fragments/compact-armor-list.hbs
@@ -36,7 +36,7 @@
   <li data-item-id="{{item.id}}" data-document-class='Item' class="item flexrow flex-group-center">
     <div class="item-name">
       <input type="checkbox" data-action="toggleArmor" data-item-id="{{item.id}}" {{#if item.system.use}}checked{{/if}}>
-      <a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a>
+      <a data-action="toggle-description" data-item-id="{{item._id}}" data-description-id="desc-readiedarmor-{{item._id}}">{{item.name}}</a>
     </div>
     <div class="item-qty item-prop">
       {{item.system.ac}}
@@ -54,7 +54,7 @@
     </div>
   </li>
   <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
-    <div class='item-description' id='item-description-{{item._id}}' style='display: none;'>
+    <div class='item-description' id='desc-readiedarmor-{{item._id}}' style='display: none;'>
       {{{item.system.description}}}
     </div>
   </li>

--- a/templates/actor/fragments/compact-armor-list.hbs
+++ b/templates/actor/fragments/compact-armor-list.hbs
@@ -1,4 +1,4 @@
-<ol class='items-list'>
+<ol class='items-list readied-armor-list'>
   <li class='flex flexrow items-header'>
     <div class='item-name'>
       {{#if (eq actorType 'character')}}
@@ -36,7 +36,7 @@
   <li data-item-id="{{item.id}}" data-document-class='Item' class="item flexrow flex-group-center">
     <div class="item-name">
       <input type="checkbox" data-action="toggleArmor" data-item-id="{{item.id}}" {{#if item.system.use}}checked{{/if}}>
-      {{item.name}}
+      <a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a>
     </div>
     <div class="item-qty item-prop">
       {{item.system.ac}}
@@ -51,6 +51,11 @@
       <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=' Item'}}' data-action='viewDoc'>
         <i class='fas fa-edit'></i>
       </a>
+    </div>
+  </li>
+  <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
+    <div class='item-description' id='item-description-{{item._id}}' style='display: none;'>
+      {{{item.system.description}}}
     </div>
   </li>
   {{/each}}

--- a/templates/actor/fragments/compact-weapon-list.hbs
+++ b/templates/actor/fragments/compact-weapon-list.hbs
@@ -1,6 +1,6 @@
 <ol class='items-list'>
-  <li class='flex flexrow items-header'>
-    <div class='item-name'>
+  <li class='grid grid-4col items-header'>
+    <div class='grid-span-2 item-name'>
       {{#if (eq actorType 'character')}}
       {{localize 'swnr.item.locationReadied'}}
       {{/if}}
@@ -8,6 +8,9 @@
     </div>
     <div class="flex-group-center item-prop">
       {{localize "swnr.weapon.damage"}}
+    </div>
+    <div class="flex-group-center item-prop">
+      {{localize "swnr.item.ammo.short"}}
     </div>
     <div class='item-controls-small'>
       {{#if @root.editable}}
@@ -23,7 +26,6 @@
         </a>
       {{/if}}
     </div>
-    <div class="flex-group-right item-controls-small"></div>
   </li>
 
   <!-- ITEM ROWS (Uses Matching Grid Layout) -->

--- a/templates/actor/fragments/compact-weapon-list.hbs
+++ b/templates/actor/fragments/compact-weapon-list.hbs
@@ -4,13 +4,13 @@
       {{#if (eq actorType 'character')}}
       {{localize 'swnr.item.locationReadied'}}
       {{/if}}
-      {{localize 'swnr.sheet.tabs.weapons-short'}}
+      {{localize 'swnr.sheet.tabs.weapons'}}
     </div>
     <div class="item-prop" style="flex: 0 0 80px; text-align: center;">
       {{localize "swnr.weapon.damage"}}
     </div>
     <div class="item-prop" style="flex: 0 0 60px; text-align: center;">
-      {{localize "swnr.item.ammo.short"}}
+      {{localize "swnr.weapon.ammo"}}
     </div>
     <div class='item-controls-small'>
       {{#if @root.editable}}

--- a/templates/actor/fragments/compact-weapon-list.hbs
+++ b/templates/actor/fragments/compact-weapon-list.hbs
@@ -32,7 +32,7 @@
           <img src='{{item.img}}' title='{{item.name}}' width='24' height='24' />
         </a>
       </div>
-      <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a></div>
+      <div><a data-action="toggle-description" data-item-id="{{item._id}}" data-description-id="desc-readiedwpn-{{item._id}}">{{item.name}}</a></div>
     </div>
     <div class="item-dmg item-prop">{{item.system.damage}}</div>
     <div class='item-controls-small'>
@@ -47,7 +47,7 @@
     </div>
   </li>
   <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
-    <div class='item-description' id='item-description-{{item._id}}' style='display: none;'>
+    <div class='item-description' id='desc-readiedwpn-{{item._id}}' style='display: none;'>
       {{{item.system.description}}}
     </div>
   </li>

--- a/templates/actor/fragments/compact-weapon-list.hbs
+++ b/templates/actor/fragments/compact-weapon-list.hbs
@@ -63,5 +63,10 @@
         </a>
       </div>
     </li>
+    <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
+      <div class='item-description' id='desc-readiedwpn-{{item._id}}' style='display: none;'>
+        {{{item.system.description}}}
+      </div>
+    </li>
   {{/each}}
 </ol>

--- a/templates/actor/fragments/compact-weapon-list.hbs
+++ b/templates/actor/fragments/compact-weapon-list.hbs
@@ -32,7 +32,7 @@
           <img src='{{item.img}}' title='{{item.name}}' width='24' height='24' />
         </a>
       </div>
-      <div>{{item.name}}</div>
+      <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a></div>
     </div>
     <div class="item-dmg item-prop">{{item.system.damage}}</div>
     <div class='item-controls-small'>
@@ -44,6 +44,11 @@
       <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=' Item'}}' data-action='viewDoc'>
         <i class='fas fa-edit'></i>
       </a>
+    </div>
+  </li>
+  <li class='item-description-row flexrow' data-item-id='{{item._id}}'>
+    <div class='item-description' id='item-description-{{item._id}}' style='display: none;'>
+      {{{item.system.description}}}
     </div>
   </li>
   {{/each}}

--- a/templates/actor/fragments/compact-weapon-list.hbs
+++ b/templates/actor/fragments/compact-weapon-list.hbs
@@ -1,15 +1,15 @@
 <ol class='items-list'>
-  <li class='grid grid-4col items-header'>
-    <div class='grid-span-2 item-name'>
+  <li class='flex flexrow items-header'>
+    <div class='item-name'>
       {{#if (eq actorType 'character')}}
       {{localize 'swnr.item.locationReadied'}}
       {{/if}}
       {{localize 'swnr.sheet.tabs.weapons-short'}}
     </div>
-    <div class="flex-group-center item-prop">
+    <div class="item-prop" style="flex: 0 0 80px; text-align: center;">
       {{localize "swnr.weapon.damage"}}
     </div>
-    <div class="flex-group-center item-prop">
+    <div class="item-prop" style="flex: 0 0 60px; text-align: center;">
       {{localize "swnr.item.ammo.short"}}
     </div>
     <div class='item-controls-small'>
@@ -28,11 +28,11 @@
     </div>
   </li>
 
-  <!-- ITEM ROWS (Uses Matching Grid Layout) -->
+  <!-- ITEM ROWS (Uses Matching Layout) -->
   {{#each itemList as |item id|}}
-    <li class="item grid grid-4col" data-item-id="{{item._id}}" data-drag="true" data-document-class="Item">
+    <li class="item flexrow flex-group-center" data-item-id="{{item._id}}" data-drag="true" data-document-class="Item">
       <!-- Name Column -->
-      <div class="grid-span-2 flex-group-left item-name">
+      <div class="item-name">
         <div class="item-image">
           <a class="rollable" data-roll-type="item" data-action="roll">
             <img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
@@ -42,19 +42,19 @@
       </div>
 
       <!-- Damage Column -->
-      <div class="flex-group-center item-prop">
+      <div class="item-prop" style="flex: 0 0 80px; text-align: center;">
         {{item.system.damage}}
       </div>
 
       <!-- Ammo Column -->
-      <div class="flex-group-center item-prop">
+      <div class="item-prop" style="flex: 0 0 60px; text-align: center;">
         {{#if (and item.system.ammo (ne item.system.ammo.type "none"))}}
           <span>{{item.system.ammo.value}} / {{item.system.ammo.max}}</span>
         {{/if}}
       </div>
 
       <!-- Controls -->
-      <div class="flex-group-right item-controls-small">
+      <div class="item-controls-small">
         {{#if (and (eq item.type "weapon") (ne item.system.ammo.type "none"))}}
           <a class="item-control item-reload" data-action="reload" title="{{localize 'swnr.sheet.reload-item'}}">
             <i class="fas fa-retweet"></i>

--- a/templates/actor/fragments/compact-weapon-list.hbs
+++ b/templates/actor/fragments/compact-weapon-list.hbs
@@ -30,10 +30,10 @@
 
   <!-- ITEM ROWS (Uses Matching Layout) -->
   {{#each itemList as |item id|}}
-    <li class="item flexrow flex-group-center" data-item-id="{{item._id}}" data-drag="true" data-document-class="Item">
+    <li class="item flexrow" data-item-id="{{item._id}}" data-drag="true" data-document-class="Item">
       <!-- Name Column -->
-      <div class="item-name">
-        <div class="item-image">
+      <div class="item-name" style="display: flex; align-items: center;">
+        <div class="item-image" style="margin-right: 0.5em;">
           <a class="rollable" data-roll-type="item" data-action="roll">
             <img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
           </a>

--- a/templates/actor/fragments/cyberware-list.hbs
+++ b/templates/actor/fragments/cyberware-list.hbs
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="">
-        {{item.name}}
+        <a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a>
           {{#if item.system.complication}}
           *
           {{/if}}
@@ -61,6 +61,11 @@
         <i class='fas fa-trash'></i>
       </a>
       {{/if}}
+    </div>
+  </li>
+  <li class="item-description-row flexrow" data-item-id="{{item._id}}">
+    <div class="item-description" id="item-description-{{item._id}}" style="display: none;">
+      {{{item.system.description}}}
     </div>
   </li>
   {{/each}}

--- a/templates/actor/fragments/cyberware-list.hbs
+++ b/templates/actor/fragments/cyberware-list.hbs
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="">
-        <a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a>
+        <a data-action="toggle-description" data-item-id="{{item._id}}" data-description-id="desc-cyberware-{{item._id}}">{{item.name}}</a>
           {{#if item.system.complication}}
           *
           {{/if}}
@@ -64,7 +64,7 @@
     </div>
   </li>
   <li class="item-description-row flexrow" data-item-id="{{item._id}}">
-    <div class="item-description" id="item-description-{{item._id}}" style="display: none;">
+    <div class="item-description" id="desc-cyberware-{{item._id}}" style="display: none;">
       {{{item.system.description}}}
     </div>
   </li>

--- a/templates/actor/fragments/items-list.hbs
+++ b/templates/actor/fragments/items-list.hbs
@@ -56,7 +56,7 @@
                 />
               </a>
             </div>
-            <div>{{item.name}}
+            <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a>
               {{#if (eq item.type "armor")}}
                 {{#if (ne item.system.soak.max 0)}}
                 ({{item.system.soak.value}}/{{item.system.soak.max}})
@@ -113,6 +113,11 @@
                 <i class='fas fa-trash'></i>
               </a>
             {{/if}}
+          </div>
+        </li>
+        <li class="item-description-row flexrow" data-item-id="{{item._id}}">
+          <div class="item-description" id="item-description-{{item._id}}" style="display: none;">
+            {{{item.system.description}}}
           </div>
         </li>
       {{/each}}

--- a/templates/actor/fragments/items-list.hbs
+++ b/templates/actor/fragments/items-list.hbs
@@ -56,7 +56,7 @@
                 />
               </a>
             </div>
-            <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a>
+            <div><a data-action="toggle-description" data-item-id="{{item._id}}" data-description-id="desc-gear-{{../type}}-{{item._id}}">{{item.name}}</a>
               {{#if (eq item.type "armor")}}
                 {{#if (ne item.system.soak.max 0)}}
                 ({{item.system.soak.value}}/{{item.system.soak.max}})
@@ -116,7 +116,7 @@
           </div>
         </li>
         <li class="item-description-row flexrow" data-item-id="{{item._id}}">
-          <div class="item-description" id="item-description-{{item._id}}" style="display: none;">
+          <div class="item-description" id="desc-gear-{{../type}}-{{item._id}}" style="display: none;">
             {{{item.system.description}}}
           </div>
         </li>

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -98,7 +98,7 @@
         {{/if}}
       </div>
       
-      <div class="resource flex-group-center actor-header-level-container"><!-- Level / HD -->
+      <div class="resource flex-group-center"><!-- Level / HD -->
         {{#if (eq actor.type 'character')}}
           <div class='resource-content header short flexrow flex-center flex-between'>
             {{formInput systemFields.level.fields.value value=system.level.value localize=true}}
@@ -123,7 +123,7 @@
         {{/if}}
       </div>
 
-      <div class="resource flex-group-center actor-header-xp-container"><!-- XP / Morale -->
+      <div class="resource flex-group-center"><!-- XP / Morale -->
         {{#if (eq actor.type 'character')}}
           {{!-- Not using form group on this one right now due to level mix in --}}
           {{!-- {{formGroup systemFields.level value=system.level localize=true widget=headerWidget}} --}}

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -98,7 +98,7 @@
         {{/if}}
       </div>
       
-      <div class="resource flex-group-center"><!-- Level / HD -->
+      <div class="resource flex-group-center actor-header-level-container"><!-- Level / HD -->
         {{#if (eq actor.type 'character')}}
           <div class='resource-content header short flexrow flex-center flex-between'>
             {{formInput systemFields.level.fields.value value=system.level.value localize=true}}
@@ -123,7 +123,7 @@
         {{/if}}
       </div>
 
-      <div class="resource flex-group-center"><!-- XP / Morale -->
+      <div class="resource flex-group-center actor-header-xp-container"><!-- XP / Morale -->
         {{#if (eq actor.type 'character')}}
           {{!-- Not using form group on this one right now due to level mix in --}}
           {{!-- {{formGroup systemFields.level value=system.level localize=true widget=headerWidget}} --}}

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -123,7 +123,7 @@
         {{/if}}
       </div>
 
-      <div class="resource flex-group-center"><!-- XP / Morale -->
+      <div class="resource flex-group-center grid-span-2"><!-- XP / Morale -->
         {{#if (eq actor.type 'character')}}
           {{!-- Not using form group on this one right now due to level mix in --}}
           {{!-- {{formGroup systemFields.level value=system.level localize=true widget=headerWidget}} --}}

--- a/templates/actor/powers.hbs
+++ b/templates/actor/powers.hbs
@@ -106,7 +106,7 @@
                 />
               </a>
             </div>
-            <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a></div>
+            <div><a data-action="toggle-description" data-item-id="{{item._id}}" data-description-id="desc-powers-{{item._id}}">{{item.name}}</a></div>
           </div>
           <div class='item-controls'>
             <a
@@ -128,7 +128,7 @@
           </div>
         </li>
         <li class="item-description-row flexrow" data-item-id="{{item._id}}">
-          <div class="item-description" id="item-description-{{item._id}}" style="display: none;">
+          <div class="item-description" id="desc-powers-{{item._id}}" style="display: none;">
             {{{item.system.description}}}
           </div>
         </li>

--- a/templates/actor/powers.hbs
+++ b/templates/actor/powers.hbs
@@ -106,7 +106,7 @@
                 />
               </a>
             </div>
-            <div>{{item.name}}</div>
+            <div><a data-action="toggle-description" data-item-id="{{item._id}}">{{item.name}}</a></div>
           </div>
           <div class='item-controls'>
             <a
@@ -125,6 +125,11 @@
                 <i class='fas fa-trash'></i>
               </a>
             {{/if}}
+          </div>
+        </li>
+        <li class="item-description-row flexrow" data-item-id="{{item._id}}">
+          <div class="item-description" id="item-description-{{item._id}}" style="display: none;">
+            {{{item.system.description}}}
           </div>
         </li>
       {{/each}}

--- a/templates/item/attribute-parts/power.hbs
+++ b/templates/item/attribute-parts/power.hbs
@@ -15,7 +15,7 @@
     {{formGroup systemFields.source value=system.source localize=true}}
     {{!-- New Favorite Checkbox --}}
     <div class="form-group">
-        <label for="system.favorite">{{localize 'SWN.Item.base.FIELDS.favorite'}}</label>
+        <label for="system.favorite">{{localize 'SWN.item.favorite'}}</label> {{!-- Changed this line --}}
         <div class="form-fields"> 
             <input type="checkbox" name="system.favorite" {{checked system.favorite}} style="margin-top: auto; margin-bottom: auto;"/>
         </div>

--- a/templates/item/attribute-parts/power.hbs
+++ b/templates/item/attribute-parts/power.hbs
@@ -15,7 +15,7 @@
     {{formGroup systemFields.source value=system.source localize=true}}
     {{!-- New Favorite Checkbox --}}
     <div class="form-group">
-        <label for="system.favorite">{{localize 'SWN.item.favorite'}}</label> {{!-- Changed this line --}}
+        <label for="system.favorite">Favorite</label> {{!-- Changed this line to plain text --}}
         <div class="form-fields"> 
             <input type="checkbox" name="system.favorite" {{checked system.favorite}} style="margin-top: auto; margin-bottom: auto;"/>
         </div>

--- a/templates/item/attribute-parts/power.hbs
+++ b/templates/item/attribute-parts/power.hbs
@@ -13,5 +13,12 @@
     {{formGroup systemFields.prepared value=system.prepared localize=true}}
     {{formGroup systemFields.effort value=system.effort localize=true}}
     {{formGroup systemFields.source value=system.source localize=true}}
+    {{!-- New Favorite Checkbox --}}
+    <div class="form-group">
+        <label for="system.favorite">{{localize 'SWN.Item.base.FIELDS.favorite'}}</label>
+        <div class="form-fields"> 
+            <input type="checkbox" name="system.favorite" {{checked system.favorite}} style="margin-top: auto; margin-bottom: auto;"/>
+        </div>
+    </div>
   </div>
 </section>


### PR DESCRIPTION
This commit introduces a new feature allowing you to click on the names of inventory items, powers, and cyberware on actor sheets to expand or collapse their descriptions.

Key changes:
- Modified Handlebars templates (`items-list.hbs`, `powers.hbs`, `cyberware-list.hbs`) to include a hidden description section for each item and make item names clickable.
- Added JavaScript logic to `SWNActorSheet` (`_onToggleDescription` method and an action in `DEFAULT_OPTIONS`) to handle the display toggle of these description sections.
- Added CSS styles to `swnr.css` for the clickable names and the appearance of the description sections, ensuring they are visually consistent with the existing UI and theme-adaptive.

This enhancement improves your experience by making detailed item information readily accessible without cluttering the sheet by default.